### PR TITLE
Fixed hero tag duplication.

### DIFF
--- a/lib/flutter_speed_dialer.dart
+++ b/lib/flutter_speed_dialer.dart
@@ -4,19 +4,23 @@ import 'package:flutter/material.dart';
 import 'dart:math' as math;
 
 /// Button tailored to using with [SpeedDialer].
+///
+/// Possiblely needs to have a hero tag different from buttons popped out
 class SpeedDialerButton extends StatelessWidget {
   IconData icon;
   String text;
   Color foregroundColor;
   Color backgroundColor;
   Function onPressed;
+  Object mainButtonHeroTag;
 
   SpeedDialerButton(
       {this.icon,
       this.text,
       this.foregroundColor,
       this.backgroundColor,
-      this.onPressed});
+      this.onPressed,
+      this.mainButtonHeroTag = 'mainFAB'});
 
   @override
   build(BuildContext context) {
@@ -25,6 +29,7 @@ class SpeedDialerButton extends StatelessWidget {
       mini: true,
       child: new Icon(icon, color: foregroundColor),
       onPressed: onPressed,
+      heroTag: this.mainButtonHeroTag,
     );
   }
 }


### PR DESCRIPTION
There is another bug causing hero tag duplication when small buttons navigate to another view. I gave the main FAB a unique hero tag and the problem disappeared.
Not sure whether it is because the main button has the same hero tag as the small buttons.